### PR TITLE
force changing haproxy password

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # tasks file for ansible-role-haproxy
 
+- name: Fail when user uses default password
+  fail:
+    msg: "Please change password for HAProxy statistics page"
+  when: haproxy_stats_pass == "PleaseChangeIt123"
+
 - include_tasks: install.yml
 
 - include_tasks: config.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Fail when user uses default password
   fail:
-    msg: "Please change password for HAProxy statistics page"
+    msg: "Please change password for HAProxy statistics page. Consider changing username if needed."
   when: haproxy_stats_pass == "PleaseChangeIt123"
 
 - include_tasks: install.yml

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -1,3 +1,4 @@
+haproxy_stats_pass: correcthorsebatterystaple
 haproxy_services:
   - name: "k8s"
     type: frontend


### PR DESCRIPTION
[If you want user to change something](https://github.com/novomatic-tech/ansible-role-haproxy#role-variables), make him really change it.

Also since this is a password, which is a security measure, I think this MUST be changed, not only SHOULD (naming convention in accordance to [RFC2119](https://www.ietf.org/rfc/rfc2119.txt))