### PR TITLE
Add firewalld configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ sudo: required
 services:
   - docker
 env:
-  - ANSIBLE='ansible>=2.4.0,<2.5.0'
   - ANSIBLE='ansible>=2.5.0,<2.6.0'
+  - ANSIBLE='ansible>=2.6.0,<2.7.0'
 install:
   - pip install ${ANSIBLE} 'ansible-lint>=3.4.15' 'molecule==1.25.0' docker git-semver 'testinfra>=1.7.0,<=1.10.1'
 before_script:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,10 +9,10 @@
   retries: 3
   when: not ansible_check_mode and ansible_facts.services is defined
 
-- name: Restart firewalld
+- name: Reload firewalld
   systemd:
     name: "firewalld"
-    state: "restarted"
+    state: "reloaded"
     enabled: "yes"
   retries: 3
   when: not ansible_check_mode and ansible_facts.services['firewalld.service'].state == 'running'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,4 +7,12 @@
     state: "restarted"
     enabled: "yes"
   retries: 3
-  when: not ansible_check_mode
+  when: not ansible_check_mode and ansible_facts.services is defined
+
+- name: Restart firewalld
+  systemd:
+    name: "firewalld"
+    state: "restarted"
+    enabled: "yes"
+  retries: 3
+  when: not ansible_check_mode and ansible_facts.services['firewalld.service'].state == 'running'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: HAProxy module for loadbalancing traffic
   company: Novomatic Technologies Poland
   license: MIT
-  min_ansible_version: 2.0
+  min_ansible_version: 2.5
   platforms:
   - name: EL
     versions:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -32,21 +32,26 @@
 - name: Gather service facts from the host
   service_facts:
 
+- name: Check if firewalld package is installed
+  yum:
+    list: firewalld
+  register: firewalld_package
+
 - name: Allow http traffic on firewalld
   firewalld:
     service: http
     permanent: true
     state: enabled
-  when: ansible_facts.services is defined
-  notify: Restart firewalld
+  when: firewalld_package.results[1].yumstate == "installed"
+  notify: Reload firewalld
 
 - name: Allow Statistics ports on firewalld
   firewalld:
     port: "{{ haproxy_stats_port }}/tcp"
     permanent: true
     state: enabled
-  when: ansible_facts.services is defined
-  notify: Restart firewalld
+  when: firewalld_package.results[1].yumstate == "installed"
+  notify: Reload firewalld
 
 - name: Create haproxy main configuration
   template:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -29,6 +29,25 @@
     persistent: yes
   when: ansible_selinux.status == 'enabled'
 
+- name: Gather service facts from the host
+  service_facts:
+
+- name: Allow http traffic on firewalld
+  firewalld:
+    service: http
+    permanent: true
+    state: enabled
+  when: ansible_facts.services is defined
+  notify: Restart firewalld
+
+- name: Allow Statistics ports on firewalld
+  firewalld:
+    port: "{{ haproxy_stats_port }}/tcp"
+    permanent: true
+    state: enabled
+  when: ansible_facts.services is defined
+  notify: Restart firewalld
+
 - name: Create haproxy main configuration
   template:
     src: haproxy.cfg.j2

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -4,5 +4,9 @@
   pre_tasks:
     - name: Include vars
       include_vars: vars.yml
+    - name: Install firewalld package
+      yum:
+        name: firewalld
+        state: present
   roles:
     - ansible-role-haproxy


### PR DESCRIPTION
Replaces the remaining code of PR #18.
When firewalld is not in running state, it still applies the rules. A firewalld service restart is needed for the rules to be enforced.
Firewalld service is only restarted if it is in running state and a change is made.
Firewall rules are skipped if no init system exists (Ex. docker container without systemd).